### PR TITLE
Wrong ESet Annotations, partially fixed

### DIFF
--- a/scripts/getMolProfile.R
+++ b/scripts/getMolProfile.R
@@ -212,8 +212,8 @@ rnaseq.iso.eSet<- ExpressionSet(assayData = as.matrix(assay.rnaseq.iso), phenoDa
 #Checks are included in the eSetToSE function
 saveRDS(eSetToSE(rna.eSet,annot_name="rna"), paste0(work_dir, "se/RNA_SE.rds"))
 saveRDS(eSetToSE(mirna.eSet,annot_name="mirna"), paste0(work_dir, "se/miRNA_SE.rds"))
-saveRDS(eSetToSE(rnaseq.comp.eSet,annot_name="rnaseq.comp"), paste0(work_dir, "se/RNA_seq_comp_SE.rds"))
-saveRDS(eSetToSE(rnaseq.iso.eSet,annot_name="rnaseq.iso"), paste0(work_dir, "se/RNA_seq_iso_SE.rds"))
+saveRDS(eSetToSE(rnaseq.comp.eSet,annot_name="rnaseq"), paste0(work_dir, "se/RNA_seq_comp_SE.rds"))
+saveRDS(eSetToSE(rnaseq.iso.eSet,annot_name="rnaseq"), paste0(work_dir, "se/RNA_seq_iso_SE.rds"))
 
 #other data to be used in downstream processing
 saveRDS(lab.cell.names, paste0(work_dir, "common/lab_cell_names.rds"))

--- a/scripts/getMolProfile.R
+++ b/scripts/getMolProfile.R
@@ -211,7 +211,7 @@ rnaseq.iso.eSet<- ExpressionSet(assayData = as.matrix(assay.rnaseq.iso), phenoDa
 ########################################### SE objects ##########################################################
 #Checks are included in the eSetToSE function
 saveRDS(eSetToSE(rna.eSet,annot_name="rna"), paste0(work_dir, "se/RNA_SE.rds"))
-saveRDS(eSetToSE(mirna.eSet,annot_name="mirna"), paste0(work_dir, "se/miRNA_SE.rds"))
+saveRDS(eSetToSE(mirna.eSet,annot_name="rna"), paste0(work_dir, "se/miRNA_SE.rds"))
 saveRDS(eSetToSE(rnaseq.comp.eSet,annot_name="rnaseq"), paste0(work_dir, "se/RNA_seq_comp_SE.rds"))
 saveRDS(eSetToSE(rnaseq.iso.eSet,annot_name="rnaseq"), paste0(work_dir, "se/RNA_seq_iso_SE.rds"))
 

--- a/scripts/getNCI60.R
+++ b/scripts/getNCI60.R
@@ -72,7 +72,7 @@ for (i in seq_along(molecularProfilesSlot(NCI60_PSet))) {
   rRanges <- rowRanges(SE)
   ## TODO:: Implement mapping for mirna if possible?
   # Skip mirna
-  if (metadata(SE)$annotation == 'mirna') next
+  if (names(molecularProfilesSlot(NCI60_PSet)[i]) == 'mirna') next
   # -- 6.2 Try look-up with Symbols
   symbol <- as.character(rRanges$Gene.name)
   # Entrez multimaps to Ensembl gene and trascript, try taking the first result


### PR DESCRIPTION
Metadata()$annotation is meant to store the type of data, not the name of the dataset (i.e. mutation, RNA, rnaseq, etc). This is used by functions in PGx that need to know whether this data is continous, discrete, categorical, etc. 

I haven't changed mirna because this is used in the getNCI60 script to not try to map them to ENSG ids. Need to first see how to change that code, but mirna should be changed to rna (which is the label for RNA microarray)